### PR TITLE
Metric value type Enchancements

### DIFF
--- a/app/(protected)/metrics/new/page.tsx
+++ b/app/(protected)/metrics/new/page.tsx
@@ -73,15 +73,15 @@ export default function NewMetricPage() {
     
     case('bloodpressure'):
 
-    handleChange('normal_range_min', '90');
-    handleChange('normal_range_max', '120');
-    break;
+      handleChange('normal_range_min', '90');
+      handleChange('normal_range_max', '120');
+      break;
     
     case('bloodsugar'):
 
-    handleChange('normal_range_min', '70');
-    handleChange('normal_range_max', '130');
-    break;
+      handleChange('normal_range_min', '70');
+      handleChange('normal_range_max', '130');
+      break;
     
    }
   }
@@ -256,9 +256,16 @@ export default function NewMetricPage() {
             
             <div className="space-y-2">
               <Label>Normal Range (Optional)</Label>
-              <p className="text-sm text-muted-foreground mb-2">
-                Set the normal/healthy range for this metric based on medical guidelines
-              </p>
+              
+                {formData.value_type=== "number" && ( 
+                <p className="text-sm text-muted-foreground mb-2">Tracks a single numeric value (e.g., weight, steps).</p>
+                )}
+               {formData.value_type=== "bloodpressure" && ( 
+                <p className="text-sm text-muted-foreground mb-2">Tracks systolic and diastolic blood pressure readings.</p>
+                )}
+                 {formData.value_type=== "bloodsugar" && ( 
+                <p className="text-sm text-muted-foreground mb-2">Tracks blood sugar levels (e.g., mg/dL or mmol/L).</p>
+                )}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
                   <Label htmlFor="normal-min" className="sr-only">Minimum normal value</Label>

--- a/app/(protected)/metrics/new/page.tsx
+++ b/app/(protected)/metrics/new/page.tsx
@@ -60,6 +60,31 @@ export default function NewMetricPage() {
     is_active: true,
   });
 
+  const handleValueTypeChange = (type: 'number' | 'bloodpressure' | 'bloodsugar') => {
+    handleChange('value_type' , type);
+
+  //data for optional normal range section based on value_type selection
+   switch(type){
+    case('number'):
+      
+      handleChange('normal_range_min', '50');
+      handleChange('normal_range_max', '100');
+      break;
+    
+    case('bloodpressure'):
+
+    handleChange('normal_range_min', '90');
+    handleChange('normal_range_max', '120');
+    break;
+    
+    case('bloodsugar'):
+
+    handleChange('normal_range_min', '70');
+    handleChange('normal_range_max', '130');
+    break;
+    
+   }
+  }
   const handleChange = (field: keyof FormData, value: any) => {
     setFormData(prev => ({ ...prev, [field]: value }));
   };
@@ -190,7 +215,7 @@ export default function NewMetricPage() {
                 <Label htmlFor="value-type">Value Type *</Label>
                 <Select 
                   value={formData.value_type} 
-                  onValueChange={(value) => handleChange('value_type', value)}
+                  onValueChange={(value) => handleValueTypeChange(value as FormData['value_type'])}
                 >
                   <SelectTrigger>
                     <SelectValue placeholder="Select value type" />


### PR DESCRIPTION
In this PR I added some basic functionality to the value_type in the metrics component. 

Before it was pretty much useless and didn't have much function and I decided instead of removing it entirely I gave it something to do.

Two changes worth noting: value_type now populates the Normal Range fields with some default data. Maybe in the future this could be customized to be the normal range for the users specific age and fitness level? The second change is the generic text above the normal and target range section now changes to be a bit more descriptive based on user selected value_type. :)