### PR TITLE
fix: prevent full habit list reload when adding/updating habits

### DIFF
--- a/app/(protected)/habits/page.tsx
+++ b/app/(protected)/habits/page.tsx
@@ -294,9 +294,6 @@ export default function HabitsPage() {
         window.dispatchEvent(new CustomEvent('refresh-reminders'));
       }
       
-      // Refresh habits to get updated streak info
-      fetchHabits();
-      
       toast({
         title: result.action === 'removed' ? "Status cleared" : "Habit updated",
         description: result.action === 'removed' 
@@ -317,8 +314,13 @@ export default function HabitsPage() {
     }
   };
 
-  const handleHabitCreated = () => {
-    fetchHabits(); // Refresh the habits list
+    
+  const handleHabitCreated = (newHabit: HabitWithStats) => {
+    setHabits(prev =>
+      newHabit && !prev.some(h => h.id === newHabit.id)
+        ? [newHabit, ...prev]
+        : prev
+    );
   };
 
   const handleNewHabitClick = () => {

--- a/components/habits/NewHabitModal.tsx
+++ b/components/habits/NewHabitModal.tsx
@@ -40,7 +40,7 @@ interface HabitCategory {
 interface NewHabitModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onHabitCreated: () => void;
+  onHabitCreated: (habit: any) => void;
 }
 
 const timesOfDay = [
@@ -180,6 +180,12 @@ export function NewHabitModal({ open, onOpenChange, onHabitCreated }: NewHabitMo
         title: "Success",
         description: "Habit created successfully!",
       });
+
+      if (data && data[0]) {
+        onHabitCreated(data[0]);
+      } else {
+        onHabitCreated(null);
+      }
       
       // Reset form
       setFormData({
@@ -194,7 +200,7 @@ export function NewHabitModal({ open, onOpenChange, onHabitCreated }: NewHabitMo
       });
       
       setShowCategoryManager(false);
-      onHabitCreated();
+      onHabitCreated(data && data[0]);
       onOpenChange(false);
     } catch (error: any) {
       toast({


### PR DESCRIPTION
1. Updated the habit list logic so adding or updating a habit no longer triggers a full reload of the entire list.
2. When a new habit is created, it’s inserted into the state without refetching all data.
3. When a habit is marked complete/incomplete, only the affected habit’s status is updated in the UI.
4. No changes to backend or database schema.
5. Fix improves UX by making habit list interactions instant and smoother.